### PR TITLE
Fix sql config incompatibility for 3.0.13

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,5 +4,4 @@ maintainer_email "ngmaloney@gmail.com"
 license          "All rights reserved"
 description      "Installs/Configures freeradius"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.2.0"
-
+version          "1.2.1"

--- a/templates/default/sql.erb
+++ b/templates/default/sql.erb
@@ -211,6 +211,10 @@ sql {
 	# Table to keep radius client info
 	client_table = "nas"
 
+	# This entry should be used for the default instance (sql {})
+	# of the SQL module.
+	group_attribute = "SQL-Group"
+
 	# Read database-specific queries
 	$INCLUDE ${modconfdir}/${.:name}/main/${dialect}/queries.conf
 }


### PR DESCRIPTION
 - Bump cookbook version to `1.2.1`
 - Update `mods-available/sql` template to include `group_attribute`

This attribute is included in the default freeradius config, though it is missing in the cookbook's template. Currently having freeradius `3.0.13` installed, `radiusd` fails to load with the following message:

```
# radiusd -XC
FreeRADIUS Version 3.0.13
Copyright (C) 1999-2017 The FreeRADIUS server project and contributors
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE
You may redistribute copies of FreeRADIUS under the terms of the
GNU General Public License
For more information about these matters, see the file named COPYRIGHT
Starting - reading configuration files ...
including dictionary file /usr/share/freeradius/dictionary
including dictionary file /usr/share/freeradius/dictionary.dhcp
including dictionary file /usr/share/freeradius/dictionary.vqp
including dictionary file /etc/raddb/dictionary
including configuration file /etc/raddb/radiusd.conf
including configuration file /etc/raddb/proxy.conf
including configuration file /etc/raddb/clients.conf
including files in directory /etc/raddb/mods-enabled/
including configuration file /etc/raddb/mods-enabled/always
including configuration file /etc/raddb/mods-enabled/attr_filter
including configuration file /etc/raddb/mods-enabled/cache_eap
including configuration file /etc/raddb/mods-enabled/chap
including configuration file /etc/raddb/mods-enabled/date
including configuration file /etc/raddb/mods-enabled/detail
including configuration file /etc/raddb/mods-enabled/detail.log
including configuration file /etc/raddb/mods-enabled/dhcp
including configuration file /etc/raddb/mods-enabled/digest
including configuration file /etc/raddb/mods-enabled/dynamic_clients
including configuration file /etc/raddb/mods-enabled/eap
including configuration file /etc/raddb/mods-enabled/echo
including configuration file /etc/raddb/mods-enabled/exec
including configuration file /etc/raddb/mods-enabled/expiration
including configuration file /etc/raddb/mods-enabled/expr
including configuration file /etc/raddb/mods-enabled/files
including configuration file /etc/raddb/mods-enabled/linelog
including configuration file /etc/raddb/mods-enabled/logintime
including configuration file /etc/raddb/mods-enabled/mschap
including configuration file /etc/raddb/mods-enabled/ntlm_auth
including configuration file /etc/raddb/mods-enabled/pap
including configuration file /etc/raddb/mods-enabled/passwd
including configuration file /etc/raddb/mods-enabled/preprocess
including configuration file /etc/raddb/mods-enabled/radutmp
including configuration file /etc/raddb/mods-enabled/realm
including configuration file /etc/raddb/mods-enabled/replicate
including configuration file /etc/raddb/mods-enabled/soh
including configuration file /etc/raddb/mods-enabled/sradutmp
including configuration file /etc/raddb/mods-enabled/unix
including configuration file /etc/raddb/mods-enabled/unpack
including configuration file /etc/raddb/mods-enabled/utf8
including configuration file /etc/raddb/mods-enabled/sql
including configuration file /etc/raddb/mods-config/sql/main/mysql/queries.conf
/etc/raddb/mods-config/sql/main/mysql/queries.conf[145]: Reference "${group_attribute}" not found
/etc/raddb/mods-config/sql/main/mysql/queries.conf[152]: Reference "${group_attribute}" not found
including files in directory /etc/raddb/policy.d/
including configuration file /etc/raddb/policy.d/accounting
including configuration file /etc/raddb/policy.d/canonicalization
including configuration file /etc/raddb/policy.d/control
including configuration file /etc/raddb/policy.d/cui
including configuration file /etc/raddb/policy.d/debug
including configuration file /etc/raddb/policy.d/dhcp
including configuration file /etc/raddb/policy.d/eap
including configuration file /etc/raddb/policy.d/filter
including configuration file /etc/raddb/policy.d/operator-name
including files in directory /etc/raddb/sites-enabled/
including configuration file /etc/raddb/sites-enabled/default
including configuration file /etc/raddb/sites-enabled/inner-tunnel
/etc/raddb/mods-config/sql/main/mysql/queries.conf[145]: Reference "${group_attribute}" not found
Errors reading or parsing /etc/raddb/radiusd.conf
```