### PR TITLE
Make cookbook compatible with Chef13

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 # OS Specific Attributes
-case platform_family
+case node['platform_family']
 when 'rhel'
   default['freeradius']['user'] = 'radiusd'
   default['freeradius']['group'] = 'radiusd'
@@ -9,7 +9,7 @@ when 'rhel'
   default['freeradius']['name'] = 'radiusd'
   default['freeradius']['libdir'] = '/usr/lib64/freeradius'
 # Packages to install since centos 5 is freeradius 2 and centos 6 is  just freeradius
-  if node.platform_version.to_f < 6
+  if node['platform_version'].to_f < 6
     default['freeradius']['pkgs'] = %w{ freeradius2 freeradius2-utils freeradius2-postgresql }
     default['freeradius']['ldap_pkgs'] = %w{ freeradius2-ldap }
   else
@@ -72,4 +72,4 @@ default['freeradius']['url'] = 'http://ftp.cc.uoc.gr/mirrors/ftp.freeradius.org/
 default['freeradius']['version'] = '2.1.10'
 default['freeradius']['checksum'] = 'b72d00d8d9c237b6bc3bfe89e6ccd99a7be63e699b305325ea60e04d5ddda4fe'
 default['freeradius']['prefix_dir'] = '/opt/local/freeradius'
-default['freeradius']['configure_options'] = %W{--prefix=#{freeradius[:prefix_dir]}/#{freeradius[:version]} --with-openssl-includes=/usr/include/openssl --with-openssl-libraries=/usr/lib}
+default['freeradius']['configure_options'] = %W{--prefix=#{node['freeradius']['prefix_dir']}/#{node['freeradius']['version']} --with-openssl-includes=/usr/include/openssl --with-openssl-libraries=/usr/lib}

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "ngmaloney@gmail.com"
 license          "All rights reserved"
 description      "Installs/Configures freeradius"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.2.1"
+version          "1.3.0"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,7 +6,7 @@
 #
 # All rights reserved - Do Not Redistribute
 #
-include_recipe "freeradius::#{node[:freeradius][:install_method]}"
+include_recipe "freeradius::#{node['freeradius']['install_method']}"
 
 if node['freeradius']['enable_ldap'] == true
   include_recipe 'freeradius::ldap'
@@ -22,7 +22,7 @@ end
 link '/etc/raddb/mods-enabled/sql' do
   to "#{node['freeradius']['dir']}/mods-available/sql"
   link_type :symbolic
-  only_if { node.platform_version.to_f >= 7 }
+  only_if { node['platform_version'].to_f >= 7 }
 end
 
 template "#{node['freeradius']['dir']}/clients.conf" do

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -6,17 +6,17 @@
 #
 # All rights reserved - Do Not Redistribute
 #
-version = node[:freeradius][:version]
-install_path = "#{node[:freeradius][:prefix_dir]}/sbin/radiusd"
+version = node['freeradius']['version']
+install_path = "#{node['freeradius']['prefix_dir']}/sbin/radiusd"
 
-remote_file "#{Chef::Config[:file_cache_path]}/freeradius-server-#{version}.tar.gz" do
-  source "#{node[:freeradius][:url]}/freeradius-server-#{version}.tar.gz"
-  checksum node[:freeradius][:checksum]
+remote_file "#{Chef::Config['file_cache_path']}/freeradius-server-#{version}.tar.gz" do
+  source "#{node['freeradius']['url']}/freeradius-server-#{version}.tar.gz"
+  checksum node['freeradius']['checksum']
   mode "0644"
-  not_if { File.exists?(install_path)}
+  not_if { File.exist?(install_path)}
 end
 
-configure_options = node[:freeradius][:configure_options].join(" ")
+configure_options = node['freeradius']['configure_options'].join(" ")
 
 bash "build-and-install-freeradius" do
   cwd Chef::Config[:file_cache_path]
@@ -25,6 +25,5 @@ bash "build-and-install-freeradius" do
   (cd freeradius-server-#{version} && ./configure #{configure_options})
   (cd freeradius-server-#{version} && make && make install)
   EOF
-  not_if { File.exists?(install_path)}
+  not_if { File.exist?(install_path)}
 end
-


### PR DESCRIPTION
Fix up attribute and recipe syntax to be compatible with Chef 12 and Chef13. No functional or logic changes.

Local `.kitchen.yml` test passes. Wrapper `vinted-freeradius` passes tests on Chef12 and Chef13.